### PR TITLE
refactor: zzapdux

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ import {
   setTheme,
 } from "./utils/index.js";
 import { addEventOnProgressBar } from "./scripts/progress-bar.js";
-import { changeTheme } from "./store/reducer.js";
+import { changeTheme } from "./store/reducer/theme.js";
 import { store } from "./store/index.js";
 
 const $headerDate = document.querySelector(".container-header_date");

--- a/constants/index.js
+++ b/constants/index.js
@@ -7,6 +7,11 @@ export const VIEW_TYPE = freeze({
   LIST: "list",
 });
 
+export const THEME = freeze({
+  LIGHT: "light",
+  DARK: "dark",
+});
+
 export const CATEGORIES = freeze([
   "종합/경제",
   "방송/통신",

--- a/core/zzapdux.js
+++ b/core/zzapdux.js
@@ -45,7 +45,6 @@ export const createStore = (reducer) => {
   const dispatch = (action) => {
     const newState = reducer(state, action);
 
-    console.log(newState);
     if (state === newState) return;
     if (JSON.stringify(state) === JSON.stringify(newState)) return;
 

--- a/core/zzapdux.js
+++ b/core/zzapdux.js
@@ -1,3 +1,26 @@
+// reducer 합치는 함수
+export const combineReducers = (reducers) => {
+  const reducerKeys = Object.keys(reducers);
+
+  return (state = {}, action) => {
+    const nextState = {};
+
+    let changed = false;
+    reducerKeys.forEach((reducerKey) => {
+      const reducer = reducers[reducerKey];
+
+      const previousState = state[reducerKey];
+      const newState = reducer(previousState, action);
+
+      nextState[reducerKey] = newState;
+
+      changed = changed || previousState !== newState;
+    });
+
+    return changed ? nextState : state;
+  };
+};
+
 export const actionCreator = (type, payload) => {
   return { type, payload };
 };
@@ -5,11 +28,11 @@ export const actionCreator = (type, payload) => {
 export const createStore = (reducer) => {
   let state = undefined;
 
+  const subscribers = [];
+
   const setState = (newState) => {
     state = newState;
   };
-
-  const subscribers = [];
 
   const getState = () => {
     return { ...state };
@@ -21,6 +44,8 @@ export const createStore = (reducer) => {
 
   const dispatch = (action) => {
     const newState = reducer(state, action);
+
+    console.log(newState);
     if (state === newState) return;
     if (JSON.stringify(state) === JSON.stringify(newState)) return;
 

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@
 - [x] 전체 언론사: 그리드 보기
   - 그리드 뉴스 랜덤 배치
   - 그리드 좌우 이동
-- [ ] 전체 언론사: 리스트 보기
+- [x] 전체 언론사: 리스트 보기
   - 콘텐츠 표시시간 20초 timeout 및 프로그레스바 애니메이션 구현
   - 언론사 순서 랜덤 배치
   - 카테고리 마지막 언론사가 보여진 후 카테고리 이동(마지막 카테고리일 시 첫 카테고리로)
@@ -22,7 +22,7 @@
   - 내가 구독한 언론사는 리스트가 default
 - [ ] 구독한 언론사: 그리드 보기
 - [ ] 구독해지 시 dialog 표시
-- [ ] 다크모드(선택)
+- [x] 다크모드(선택)
 
 ## 디렉토리 구조
 
@@ -35,15 +35,20 @@ newsstand
 │  └─ images
 │     ├─ dark
 │     └─ light
-├─ constants // 상수
-├─ db.js
+├─ constants // 상수 모듈
+├─ core // core 로직
+├─ mocks // mock data
+├─ scripts // js scripts
+├─ store // global store
+│  ├─ index.js
+│  └─ reducer // reducer(state를 변경하는 함수들)
+│     ├─ page.js
+│     └─ theme.js
+├─ styles // style files
+├─ utils // util functions
 ├─ index.html
-├─ makeMocks.js
-├─ mocks // mock 데이터
-├─ package.json
-├─ readme.md
-├─ scripts // js scripts 파일들
 ├─ style.css
-├─ styles // style 파일들
-└─ utils // 유틸 함수들
+├─ makeMocks.js
+├─ package.json
+└─ readme.md
 ```

--- a/scripts/grid-view.js
+++ b/scripts/grid-view.js
@@ -1,9 +1,9 @@
 import { NEWS_COUNT, VIEW_TYPE } from "../constants/index.js";
-import { store } from "../store/index.js";
+import { store, useSelector } from "../store/index.js";
 import { $nextPageButton, $prevPageButton } from "./doms.js";
 
 const fillGridView = (newsData, currentPage) => {
-  const theme = store.getState().theme;
+  const theme = useSelector((state) => state.theme.currentTheme);
   const $gridView = document.querySelector(".grid-view");
   $gridView.innerHTML = "";
 
@@ -28,7 +28,7 @@ const fillGridView = (newsData, currentPage) => {
 };
 
 const initGridView = (newsData) => {
-  const currentPage = store.getState().currentPage;
+  const currentPage = useSelector((state) => state.page.currentPage);
   fillGridView(newsData, currentPage);
 };
 
@@ -55,7 +55,7 @@ export const renderGridView = (newsData) => {
   initGridView(newsData);
 
   store.subscribe(() => {
-    const { currentPage, viewType } = store.getState();
+    const { currentPage, viewType } = useSelector((state) => state.page);
     if (viewType !== VIEW_TYPE.GRID) return;
 
     fillGridView(newsData, currentPage);

--- a/scripts/list-view.js
+++ b/scripts/list-view.js
@@ -1,6 +1,6 @@
 import { NewsDB } from "../core/index.js";
 import { store, useSelector } from "../store/index.js";
-import { VIEW_TYPE } from "../constants/index.js";
+import { CATEGORIES, VIEW_TYPE } from "../constants/index.js";
 import { $nextPageButton, $prevPageButton } from "./doms.js";
 import {
   nextCategory,
@@ -86,11 +86,12 @@ export const renderListView = () => {
   });
 
   store.subscribe(() => {
-    const { currentPage, currentCategory, viewType } = useSelector(
+    const { currentPage, currentCategoryIdx, viewType } = useSelector(
       (state) => state.page
     );
     if (viewType !== VIEW_TYPE.LIST) return;
 
+    const currentCategory = CATEGORIES[currentCategoryIdx];
     const totalCnt = NewsDB.getCountByCategory(currentCategory);
 
     if (currentPage < 0) {

--- a/scripts/list-view.js
+++ b/scripts/list-view.js
@@ -1,8 +1,12 @@
 import { NewsDB } from "../core/index.js";
-import { store } from "../store/index.js";
+import { store, useSelector } from "../store/index.js";
 import { VIEW_TYPE } from "../constants/index.js";
 import { $nextPageButton, $prevPageButton } from "./doms.js";
-import { nextCategory, prevCategory, setCategory } from "../store/reducer.js";
+import {
+  nextCategory,
+  prevCategory,
+  setCategory,
+} from "../store/reducer/page.js";
 import { resetProgress } from "./progress-bar.js";
 
 const $listViewTab = document.querySelector(".list-view_tab > ul");
@@ -23,7 +27,7 @@ const $listViewSubNews = $listViewMain.querySelector(
 const $listViewNotice = $listViewMain.querySelector(".list-view-main_notice");
 
 const fillArticles = (currentCategory, currentPage) => {
-  const theme = store.getState().theme;
+  const theme = useSelector((state) => state.theme.currentTheme);
   const { name, src, edit_date, main_news, sub_news } =
     NewsDB.queryByCategory(currentCategory)[currentPage];
 
@@ -82,7 +86,9 @@ export const renderListView = () => {
   });
 
   store.subscribe(() => {
-    const { currentPage, currentCategory, viewType } = store.getState();
+    const { currentPage, currentCategory, viewType } = useSelector(
+      (state) => state.page
+    );
     if (viewType !== VIEW_TYPE.LIST) return;
 
     const totalCnt = NewsDB.getCountByCategory(currentCategory);

--- a/scripts/pagination-button.js
+++ b/scripts/pagination-button.js
@@ -1,5 +1,5 @@
 import { store } from "../store/index.js";
-import { nextPage, prevPage } from "../store/reducer.js";
+import { nextPage, prevPage } from "../store/reducer/page.js";
 import { $nextPageButton, $prevPageButton } from "./doms.js";
 
 const handlePrevButtonClick = () => {

--- a/scripts/progress-bar.js
+++ b/scripts/progress-bar.js
@@ -1,11 +1,11 @@
 import { NewsDB } from "../core/db.js";
-import { store } from "../store/index.js";
-import { nextCategory, nextPage } from "../store/reducer.js";
+import { store, useSelector } from "../store/index.js";
+import { nextCategory, nextPage } from "../store/reducer/page.js";
 
 const $listViewTab = document.querySelector(".list-view_tab");
 
 const handleProgressAnimationIteration = () => {
-  const { currentCategory, currentPage } = store.getState();
+  const { currentCategory, currentPage } = useSelector((state) => state.page);
   const totalCount = NewsDB.getCountByCategory(currentCategory);
 
   if (totalCount - 1 === currentPage) {

--- a/scripts/progress-bar.js
+++ b/scripts/progress-bar.js
@@ -1,3 +1,4 @@
+import { CATEGORIES } from "../constants/index.js";
 import { NewsDB } from "../core/db.js";
 import { store, useSelector } from "../store/index.js";
 import { nextCategory, nextPage } from "../store/reducer/page.js";
@@ -5,7 +6,10 @@ import { nextCategory, nextPage } from "../store/reducer/page.js";
 const $listViewTab = document.querySelector(".list-view_tab");
 
 const handleProgressAnimationIteration = () => {
-  const { currentCategory, currentPage } = useSelector((state) => state.page);
+  const { currentCategoryIdx, currentPage } = useSelector(
+    (state) => state.page
+  );
+  const currentCategory = CATEGORIES[currentCategoryIdx];
   const totalCount = NewsDB.getCountByCategory(currentCategory);
 
   if (totalCount - 1 === currentPage) {

--- a/scripts/viewer-button.js
+++ b/scripts/viewer-button.js
@@ -1,5 +1,5 @@
-import { store } from "../store/index.js";
-import { changeView } from "../store/reducer.js";
+import { store, useSelector } from "../store/index.js";
+import { changeView } from "../store/reducer/page.js";
 import { VIEW_TYPE } from "../constants/index.js";
 import { $gridView, $listView } from "./doms.js";
 
@@ -15,7 +15,7 @@ const handleViewerButtonClick = (e) => {
 
 export const addEventOnViewerButton = () => {
   store.subscribe(() => {
-    const viewType = store.getState().viewType;
+    const viewType = useSelector((state) => state.page.viewType);
 
     $mainNavViewerButtons.forEach(($button) => {
       if (viewType !== $button.dataset.view) {

--- a/store/index.js
+++ b/store/index.js
@@ -1,4 +1,11 @@
-import { createStore } from "../core/index.js";
-import { reducer } from "./reducer.js";
+import { combineReducers, createStore } from "../core/index.js";
+import { page } from "./reducer/page.js";
+import { theme } from "./reducer/theme.js";
 
-export const store = createStore(reducer);
+const rootReducer = combineReducers({ page, theme });
+
+export const store = createStore(rootReducer);
+
+export const useSelector = (selector) => {
+  return selector(store.getState());
+};

--- a/store/reducer/page.js
+++ b/store/reducer/page.js
@@ -5,14 +5,11 @@ import {
 } from "../../constants/index.js";
 import { actionCreator } from "../../core/index.js";
 
-// TODO: reducer가 외부 변수를 참조하고 있음. 추후 순수함수로 만들어야 함.
-let categoryIdx = 0;
-
 const categoryCount = CATEGORIES.length;
 
 const initialState = {
   currentPage: 0,
-  currentCategory: CATEGORIES[categoryIdx],
+  currentCategoryIdx: 0,
   viewType: VIEW_TYPE.GRID,
 };
 
@@ -35,44 +32,54 @@ export const setCategory = (category) => actionCreator(SET_CATEGORY, category);
 export const page = (state = initialState, action) => {
   switch (action.type) {
     case NEXT_PAGE:
-      return { ...state, currentPage: state.currentPage + 1 };
+      return {
+        ...state,
+        currentPage: state.currentPage + 1,
+      };
     case PREV_PAGE:
-      return { ...state, currentPage: state.currentPage - 1 };
+      return {
+        ...state,
+        currentPage: state.currentPage - 1,
+      };
     case RESET_PAGE:
-      return { ...state, currentPage: 0 };
-    case CHANGE_VIEW:
-      categoryIdx = 0;
       return {
         ...state,
         currentPage: 0,
-        currentCategory: CATEGORIES[categoryIdx],
+      };
+    case CHANGE_VIEW:
+      return {
+        ...state,
+        currentPage: 0,
+        currentCategoryIdx: 0,
         viewType: action.payload,
       };
     case NEXT_CATEGORY:
-      categoryIdx = categoryIdx === categoryCount - 1 ? 0 : categoryIdx + 1;
-
       return {
         ...state,
-        currentCategory: CATEGORIES[categoryIdx],
+        currentCategoryIdx: getNextCategoryIdx(state.currentCategoryIdx),
         currentPage: 0,
       };
     case PREV_CATEGORY:
-      categoryIdx = categoryIdx === 0 ? categoryCount - 1 : categoryIdx - 1;
-
       return {
         ...state,
-        currentCategory: CATEGORIES[categoryIdx],
+        currentCategoryIdx: getPrevCategoryIdx(state.currentCategoryIdx),
         currentPage: 0,
       };
     case SET_CATEGORY:
-      categoryIdx = CATEGORIES_TO_INDEX[action.payload];
-
       return {
         ...state,
-        currentCategory: action.payload,
+        currentCategoryIdx: CATEGORIES_TO_INDEX[action.payload],
         currentPage: 0,
       };
     default:
       return state;
+  }
+
+  function getPrevCategoryIdx(idx) {
+    return idx === 0 ? categoryCount - 1 : idx - 1;
+  }
+
+  function getNextCategoryIdx(idx) {
+    return idx === categoryCount - 1 ? 0 : idx + 1;
   }
 };

--- a/store/reducer/page.js
+++ b/store/reducer/page.js
@@ -2,8 +2,8 @@ import {
   VIEW_TYPE,
   CATEGORIES,
   CATEGORIES_TO_INDEX,
-} from "../constants/index.js";
-import { actionCreator } from "../core/index.js";
+} from "../../constants/index.js";
+import { actionCreator } from "../../core/index.js";
 
 // TODO: reducer가 외부 변수를 참조하고 있음. 추후 순수함수로 만들어야 함.
 let categoryIdx = 0;
@@ -14,8 +14,6 @@ const initialState = {
   currentPage: 0,
   currentCategory: CATEGORIES[categoryIdx],
   viewType: VIEW_TYPE.GRID,
-
-  theme: "light",
 };
 
 const NEXT_PAGE = "PAGE/NEXT_PAGE";
@@ -25,7 +23,6 @@ const CHANGE_VIEW = "PAGE/CHANGE_VIEW";
 const NEXT_CATEGORY = "PAGE/NEXT_CATEGORY";
 const PREV_CATEGORY = "PAGE/PREV_CATEGORY";
 const SET_CATEGORY = "PAGE/SET_CATEGORY";
-const CHANGE_THEME = "PAGE/CHANGE_THEME";
 
 export const nextPage = () => actionCreator(NEXT_PAGE);
 export const prevPage = () => actionCreator(PREV_PAGE);
@@ -34,9 +31,8 @@ export const changeView = (viewType) => actionCreator(CHANGE_VIEW, viewType);
 export const nextCategory = () => actionCreator(NEXT_CATEGORY);
 export const prevCategory = () => actionCreator(PREV_CATEGORY);
 export const setCategory = (category) => actionCreator(SET_CATEGORY, category);
-export const changeTheme = () => actionCreator(CHANGE_THEME);
 
-export const reducer = (state = initialState, action) => {
+export const page = (state = initialState, action) => {
   switch (action.type) {
     case NEXT_PAGE:
       return { ...state, currentPage: state.currentPage + 1 };
@@ -75,11 +71,6 @@ export const reducer = (state = initialState, action) => {
         ...state,
         currentCategory: action.payload,
         currentPage: 0,
-      };
-    case CHANGE_THEME:
-      return {
-        ...state,
-        theme: state.theme === "light" ? "dark" : "light",
       };
     default:
       return state;

--- a/store/reducer/theme.js
+++ b/store/reducer/theme.js
@@ -1,7 +1,8 @@
+import { THEME } from "../../constants/index.js";
 import { actionCreator } from "../../core/zzapdux.js";
 
 const initialState = {
-  currentTheme: "light",
+  currentTheme: THEME.LIGHT,
 };
 
 const CHANGE_THEME = "PAGE/CHANGE_THEME";
@@ -13,7 +14,8 @@ export const theme = (state = initialState, action) => {
     case CHANGE_THEME:
       return {
         ...state,
-        currentTheme: state.currentTheme === "light" ? "dark" : "light",
+        currentTheme:
+          state.currentTheme === THEME.LIGHT ? THEME.DARK : THEME.LIGHT,
       };
     default:
       return state;

--- a/store/reducer/theme.js
+++ b/store/reducer/theme.js
@@ -1,0 +1,21 @@
+import { actionCreator } from "../../core/zzapdux.js";
+
+const initialState = {
+  currentTheme: "light",
+};
+
+const CHANGE_THEME = "PAGE/CHANGE_THEME";
+
+export const changeTheme = () => actionCreator(CHANGE_THEME);
+
+export const theme = (state = initialState, action) => {
+  switch (action.type) {
+    case CHANGE_THEME:
+      return {
+        ...state,
+        currentTheme: state.currentTheme === "light" ? "dark" : "light",
+      };
+    default:
+      return state;
+  }
+};

--- a/utils/theme.js
+++ b/utils/theme.js
@@ -1,7 +1,7 @@
-import { store } from "../store/index.js";
+import { useSelector } from "../store/index.js";
 
 export const setTheme = () => {
-  const theme = store.getState().theme;
+  const theme = useSelector((state) => state.theme.currentTheme);
 
   if (theme === "dark") {
     document.documentElement.classList.add("dark");

--- a/utils/theme.js
+++ b/utils/theme.js
@@ -1,11 +1,12 @@
+import { THEME } from "../constants/index.js";
 import { useSelector } from "../store/index.js";
 
 export const setTheme = () => {
   const theme = useSelector((state) => state.theme.currentTheme);
 
-  if (theme === "dark") {
-    document.documentElement.classList.add("dark");
+  if (theme === THEME.DARK) {
+    document.documentElement.classList.add(THEME.DARK);
   } else {
-    document.documentElement.classList.remove("dark");
+    document.documentElement.classList.remove(THEME.DARK);
   }
 };


### PR DESCRIPTION
## :eyes: What is this PR?

zzapdux를 refactoring (combineReducers 구현, reducer 외부변수 제거)

## :pencil: Changes

### combineReducers 구현

reducer를 합친 reducer를 반환하는 `combineReducers` 함수를 구현했습니다.

```javascript
const combineReducers = (reducers) => {
  // 각 reducer의 이름을 state에 key로 저장
  const reducerKeys = Object.keys(reducers);

  return (state = {}, action) => {
    const nextState = {};

    let changed = false;

    // 각 reducer에 대해서 state와 action을 전달해 새로운 state로 갱신
    reducerKeys.forEach((reducerKey) => {
      const reducer = reducers[reducerKey];

      const previousState = state[reducerKey];
      const newState = reducer(previousState, action);

      nextState[reducerKey] = newState;
      
      changed = changed || previousState !== newState;
    });
    
    // 이전과 바뀐 state가 있다면 바뀐 state를 반환하고 아닐 시 이전의 state 반환
    return changed ? nextState : state;
  };
};
```
```javascript
// store/index.js

// rootReducer를 만들어서 사용한다.
const rootReducer = combineReducers({ page, theme });
export const store = createStore(rootReducer);
```

### useSelector 구현

reducer를 여러개 합쳤으므로 store의 state를 가져올때 reducerKey를 거쳐서 state에 접근해야 하므로 쉽게 select를 할 수 있는 유틸함수인 `useSelector()`를 구현했습니다.

```javascript
export const useSelector = (selector) => {
  return selector(store.getState());
};

// 사용할 때
const theme = useSelector((state) => state.theme.currentTheme);

const { currentPage, currentCategoryIdx, viewType } = useSelector(
      (state) => state.page
    );
```

### pageReducer 순수함수로 개선

순수함수여야 하는 pageReducer에서 외부변수 categoryIdx를 참조하던 문제가 있어 내부에서 관리하는 state를 currentCategory가 아닌 currentCategoryIdx로 변경

> CATEGORIES 및 CATEGORIES_TO_INDEX의 경우 상수이기 때문에 외부 참조를 해도 사이드이펙트가 발생하지 않을꺼라 판단

## :camera: Attachment(optional)