### PR TITLE
feature: 구독 해지 기능 구현

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,6 +16,7 @@ import { store } from "./store/index.js";
 import { setSnackbar } from "./scripts/snackbar.js";
 import { initSubscribe } from "./store/reducer/subscribe-list.js";
 import { getLocalStorageItem } from "./utils/local-storage.js";
+import { setModal } from "./scripts/modal.js";
 
 const $headerDate = document.querySelector(".container-header_date");
 
@@ -49,6 +50,7 @@ const addEventOnThemeButton = () => {
 
   setHeaderDate();
   setSnackbar();
+  setModal();
   startRollingBanner();
 
   renderGridView(newsData);

--- a/index.html
+++ b/index.html
@@ -262,5 +262,14 @@
     <div class="display-medium16 snackbar">
       내가 구독한 언론사에 추가되었습니다.
     </div>
+    <div class="modal">
+      <pre class="modal_contents display-medium16">
+        <p><span class="contents_press-name"></span>을(를)</p>
+        <p>구독해지하시겠습니까?</p>
+      </pre>
+      <div class="modal_btns">
+        <button class="btns_confirm">예, 해지합니다</button>
+        <button class="btns_cancel">아니오</button>
+    </div>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -262,7 +262,7 @@
     <div class="display-medium16 snackbar">
       내가 구독한 언론사에 추가되었습니다.
     </div>
-    <div class="modal">
+    <div class="modal hidden">
       <pre class="modal_contents display-medium16">
         <p><span class="contents_press-name"></span>을(를)</p>
         <p>구독해지하시겠습니까?</p>

--- a/scripts/grid-view.js
+++ b/scripts/grid-view.js
@@ -1,5 +1,6 @@
 import { NEWS_COUNT, VIEW_TYPE } from "../constants/index.js";
 import { store, useSelector } from "../store/index.js";
+import { openModal } from "../store/reducer/modal.js";
 import { openSnackbar } from "../store/reducer/snackbar.js";
 import { addSubscribe } from "../store/reducer/subscribe-list.js";
 import { SubscribeButton } from "./components.js";
@@ -31,12 +32,13 @@ const fillGridView = (newsData, currentPage) => {
 
 const handleSubscribeButtonClick = (e) => {
   const $button = e.target.closest(".subscribe-btn");
-  const name = $button.previousElementSibling.alt;
+  if (!$button) return;
 
+  const name = $button.previousElementSibling.alt;
   const isSubscribed = JSON.parse($button.dataset.subscribed);
 
   if (isSubscribed) {
-    // TODO: 구독해지 로직
+    store.dispatch(openModal(name));
     return;
   }
 

--- a/scripts/list-view.js
+++ b/scripts/list-view.js
@@ -11,6 +11,7 @@ import { resetProgress } from "./progress-bar.js";
 import { SubscribeButton } from "./components.js";
 import { openSnackbar } from "../store/reducer/snackbar.js";
 import { addSubscribe } from "../store/reducer/subscribe-list.js";
+import { openModal } from "../store/reducer/modal.js";
 
 const $listViewTab = document.querySelector(".list-view_tab > ul");
 const $listViewTabItems = $listViewTab.querySelectorAll("li");
@@ -89,12 +90,16 @@ const handleListViewTabClick = (e) => {
 
 const handleSubscribeButtonClick = (e) => {
   const $button = e.target.closest(".subscribe-btn");
-  const name = $button.previousElementSibling.previousElementSibling.alt;
+  if (!$button) {
+    return;
+  }
 
+  const name = $button.previousElementSibling.previousElementSibling.alt;
   const isSubscribed = JSON.parse($button.dataset.subscribed);
 
   if (isSubscribed) {
-    // TODO: 구독해지 로직
+    console.log(name);
+    store.dispatch(openModal(name));
     return;
   }
 

--- a/scripts/modal.js
+++ b/scripts/modal.js
@@ -1,0 +1,49 @@
+import { store, useSelector } from "../store/index.js";
+import { closeModal } from "../store/reducer/modal.js";
+import { cancelSubscribe } from "../store/reducer/subscribe-list.js";
+
+const $modal = document.querySelector(".modal");
+const $confirmButton = $modal.querySelector(".btns_confirm");
+const $cancelButton = $modal.querySelector(".btns_cancel");
+
+let handlerOnConfirmButton;
+
+const handleClickOutSideModal = (e) => {
+  const open = useSelector((state) => state.modal.open);
+  if (!open) return;
+  if (e.target.closest(".modal") || e.target.closest(".subscribe-btn")) return;
+
+  store.dispatch(closeModal());
+};
+
+const handleClickModalCancelButton = () => {
+  store.dispatch(closeModal());
+};
+
+const replaceEventListenerOnConfirmButton = (press) => {
+  $confirmButton.removeEventListener("click", handlerOnConfirmButton);
+  handlerOnConfirmButton = () => {
+    store.dispatch(cancelSubscribe(press));
+    store.dispatch(closeModal());
+  };
+  $confirmButton.addEventListener("click", handlerOnConfirmButton);
+};
+
+export const setModal = () => {
+  window.addEventListener("click", handleClickOutSideModal);
+  $cancelButton.addEventListener("click", handleClickModalCancelButton);
+
+  store.subscribe(() => {
+    const { open, press } = useSelector((state) => state.modal);
+
+    if (open) {
+      $modal.querySelector(".contents_press-name").innerText = press;
+      $modal.classList.remove("hidden");
+
+      replaceEventListenerOnConfirmButton(press);
+      return;
+    }
+
+    $modal.classList.add("hidden");
+  });
+};

--- a/store/index.js
+++ b/store/index.js
@@ -3,8 +3,15 @@ import { page } from "./reducer/page.js";
 import { theme } from "./reducer/theme.js";
 import { snackbar } from "./reducer/snackbar.js";
 import { subscribeList } from "./reducer/subscribe-list.js";
+import { modal } from "./reducer/modal.js";
 
-const rootReducer = combineReducers({ page, theme, snackbar, subscribeList });
+const rootReducer = combineReducers({
+  page,
+  theme,
+  snackbar,
+  modal,
+  subscribeList,
+});
 
 export const store = createStore(rootReducer);
 

--- a/store/reducer/modal.js
+++ b/store/reducer/modal.js
@@ -1,0 +1,23 @@
+import { actionCreator } from "../../core/zzapdux.js";
+
+const initialState = {
+  open: false,
+  press: "",
+};
+
+const OPEN_MODAL = "MODAL/OPEN_MODAL";
+const CLOSE_MODAL = "MODAL/CLOSE_MODAL";
+
+export const openModal = (press) => actionCreator(OPEN_MODAL, press);
+export const closeModal = () => actionCreator(CLOSE_MODAL);
+
+export const modal = (state = initialState, action) => {
+  switch (action.type) {
+    case OPEN_MODAL:
+      return { ...state, open: true, press: action.payload };
+    case CLOSE_MODAL:
+      return { ...state, open: false };
+    default:
+      return state;
+  }
+};

--- a/style.css
+++ b/style.css
@@ -134,6 +134,53 @@ body {
   box-shadow: 0px 2px 18px 0px rgba(20, 33, 43, 0.08),
     0px 4px 2px 0px rgba(20, 33, 43, 0.02);
 }
+.modal {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 320px;
+
+  color: var(--color-text-default);
+  border: 1px solid var(--color-border-default);
+  box-shadow: 0px 2px 18px 0px rgba(20, 33, 43, 0.08),
+    0px 4px 2px 0px rgba(20, 33, 43, 0.02);
+
+  z-index: 10;
+}
+.modal_contents {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  padding: 24px;
+  border-bottom: 1px solid var(--color-border-default);
+  background-color: var(--color-surface-default);
+}
+.modal_contents .contents_press-name {
+  color: var(--color-text-strong);
+}
+.modal_btns {
+  width: 100%;
+  display: flex;
+
+  background-color: var(--color-surface-alt);
+}
+.modal_btns > button {
+  flex: 1;
+  padding: 10px;
+}
+.modal_btns > button:first-child {
+  border-right: 1px solid var(--color-border-default);
+}
+.modal_btns > button:hover {
+  text-decoration-line: underline;
+}
+.modal_btns .btns_cancel {
+  color: var(--color-text-strong);
+}
 .theme-btn:hover {
   box-shadow: 0px 0px 8px 6px var(--color-text-default);
 }


### PR DESCRIPTION
## :eyes: What is this PR?

구독해지 기능 구현
- close #15

## :pencil: Changes

- 구독해지 모달 마크업 및 스타일링
- modal global state 추가 -> (현재 모달 열기 상태 & 모달에 띄울 언론사 명)
- 그리드 뷰와 리스트 뷰에서 해지하기 버튼 클릭시 openModal action dispatch
- 모달에선 열린 상태와 닫힌 상태에 따라 다르게 동작하는 리스너함수 등록
```javascript
store.subscribe(() => {
    const { open, press } = useSelector((state) => state.modal);

    if (open) {
      $modal.querySelector(".contents_press-name").innerText = press;
      $modal.classList.remove("hidden");
      
      // 클릭 시 press명이 다르기 때문에 eventListener를 교체해주어야 함.
      replaceEventListenerOnConfirmButton(press);
      return;
    }

    $modal.classList.add("hidden");
  });
```
- 모달 바깥 클릭 시 모달이 닫히게 구현
event bubbling 중에 모달이 발견되지 않으면 바깥을 클릭한 것으로 간주, 또한 해지버튼을 눌렀을 때는 모달을 닫으면 안되기 때문에 닫히지 않게 예외처리 -> 이것을 예외처리 하지 않으면 해지버튼을 눌렀을때 모달이 켜짐과 동시에 꺼짐
```javascript
const handleClickOutSideModal = (e) => {
  const open = useSelector((state) => state.modal.open);
  if (!open) return;
  if (e.target.closest(".modal") || e.target.closest(".subscribe-btn")) return;

  store.dispatch(closeModal());
};
```
## :camera: Attachment(optional)

구독/해지 기능

https://github.com/asdf99245/fe-newsstand/assets/39851220/f0182f94-0edc-4de5-97a8-c5b4014724a5

로컬 스토리지 해지

https://github.com/asdf99245/fe-newsstand/assets/39851220/381819e0-2fdc-4c77-9168-5c923b2cd327


