### PR TITLE
feature: 구독한 언론사 탭 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
           <div class="list-view hidden">
             <header>
               <nav class="list-view_tab">
-                <ul class="available-medium14">
+                <ul class="tab-all available-medium14">
                   <li class="category-selected selected-bold14">
                     <div class="tab_progress-bar"></div>
                     <span class="tab_category">종합/경제</span>
@@ -200,6 +200,7 @@
                     </div>
                   </li>
                 </ul>
+                <ul class="tab-subscribe available-medium14"></ul>
               </nav>
             </header>
             <main class="list-view-main">

--- a/scripts/list-view.js
+++ b/scripts/list-view.js
@@ -60,10 +60,10 @@ const unshowCategoryTab = () => {
   $categoryTab.style.display = "none";
 };
 
-const fillArticles = (currentCategory, currentPage) => {
+const fillArticle = (articleData) => {
   const theme = useSelector((state) => state.theme.currentTheme);
-  const { name, src, edit_date, main_news, sub_news } =
-    NewsDB.queryByCategory(currentCategory)[currentPage];
+  const { name, src, edit_date, main_news, sub_news } = articleData;
+
   const subscribeList = useSelector((state) => state.subscribeList);
   const isSubscribed = subscribeList.includes(name);
 
@@ -171,15 +171,24 @@ export const renderListView = () => {
     }
 
     if (tabType === TAB_TYPE.ALL) {
+      const articleData = NewsDB.queryByCategory(currentCategory)[currentPage];
+
       showCategoryTab();
       unshowSubscribeTab();
       activateCategory(currentCategory);
       showTabCount(currentPage, totalCnt);
-      fillArticles(currentCategory, currentPage);
+      fillArticle(articleData);
     } else {
       const subscribeList = useSelector((state) => state.subscribeList);
+      const pressName = subscribeList[currentPage];
+      const articleData = {
+        name: pressName,
+        ...NewsDB.getNewsOneByName(pressName),
+      };
+
       unshowCategoryTab();
       showSubscribeTab(subscribeList, subscribeList[currentPage]);
+      fillArticle(articleData);
     }
     resetProgress();
     updateButtonUI();

--- a/scripts/list-view.js
+++ b/scripts/list-view.js
@@ -157,21 +157,20 @@ export const renderListView = () => {
     );
     if (viewType !== VIEW_TYPE.LIST) return;
 
-    const currentCategory = CATEGORIES[currentCategoryIdx];
-    const totalCnt = NewsDB.getCountByCategory(currentCategory);
-
-    if (currentPage < 0) {
-      store.dispatch(prevCategory());
-      return;
-    }
-
-    if (currentPage >= totalCnt) {
-      store.dispatch(nextCategory());
-      return;
-    }
-
     if (tabType === TAB_TYPE.ALL) {
+      const currentCategory = CATEGORIES[currentCategoryIdx];
+      const totalCnt = NewsDB.getCountByCategory(currentCategory);
       const articleData = NewsDB.queryByCategory(currentCategory)[currentPage];
+
+      if (currentPage < 0) {
+        store.dispatch(prevCategory());
+        return;
+      }
+
+      if (currentPage >= totalCnt) {
+        store.dispatch(nextCategory());
+        return;
+      }
 
       showCategoryTab();
       unshowSubscribeTab();
@@ -185,6 +184,16 @@ export const renderListView = () => {
         name: pressName,
         ...NewsDB.getNewsOneByName(pressName),
       };
+
+      if (currentPage < 0) {
+        store.dispatch(setPage(subscribeList.length - 1));
+        return;
+      }
+
+      if (currentPage >= subscribeList.length) {
+        store.dispatch(setPage(0));
+        return;
+      }
 
       unshowCategoryTab();
       showSubscribeTab(subscribeList, subscribeList[currentPage]);

--- a/scripts/snackbar.js
+++ b/scripts/snackbar.js
@@ -1,4 +1,6 @@
+import { TAB_TYPE, VIEW_TYPE } from "../constants/index.js";
 import { store, useSelector } from "../store/index.js";
+import { changeTab } from "../store/reducer/page.js";
 import { closeSnackbar } from "../store/reducer/snackbar.js";
 
 const SNACKBAR_SHOW_DURATION = "5000";
@@ -9,6 +11,7 @@ let timer;
 export const setSnackbar = () => {
   store.subscribe(() => {
     const open = useSelector((state) => state.snackbar.open);
+    const viewType = useSelector((state) => state.page.viewType);
 
     if (open) {
       $snackbar.classList.add("snackbar-open");
@@ -16,6 +19,10 @@ export const setSnackbar = () => {
 
       timer = setTimeout(() => {
         store.dispatch(closeSnackbar());
+
+        if (viewType === VIEW_TYPE.LIST) {
+          store.dispatch(changeTab(TAB_TYPE.SUBSCRIBE));
+        }
       }, SNACKBAR_SHOW_DURATION);
 
       return;

--- a/store/reducer/page.js
+++ b/store/reducer/page.js
@@ -18,6 +18,7 @@ const initialState = {
 const NEXT_PAGE = "PAGE/NEXT_PAGE";
 const PREV_PAGE = "PAGE/PREV_PAGE";
 const RESET_PAGE = "PAGE/RESET_PAGE";
+const SET_PAGE = "PAGE/SET_PAGE";
 const CHANGE_VIEW = "PAGE/CHANGE_VIEW";
 const CHANGE_TAB = "PAGE/CHANGE_TAB";
 const NEXT_CATEGORY = "PAGE/NEXT_CATEGORY";
@@ -27,6 +28,7 @@ const SET_CATEGORY = "PAGE/SET_CATEGORY";
 export const nextPage = () => actionCreator(NEXT_PAGE);
 export const prevPage = () => actionCreator(PREV_PAGE);
 export const resetPage = () => actionCreator(RESET_PAGE);
+export const setPage = (page) => actionCreator(SET_PAGE, page);
 export const changeView = (viewType) => actionCreator(CHANGE_VIEW, viewType);
 export const changeTab = (tabType) => actionCreator(CHANGE_TAB, tabType);
 export const nextCategory = () => actionCreator(NEXT_CATEGORY);
@@ -49,6 +51,11 @@ export const page = (state = initialState, action) => {
       return {
         ...state,
         currentPage: 0,
+      };
+    case SET_PAGE:
+      return {
+        ...state,
+        currentPage: action.payload,
       };
     case CHANGE_VIEW:
       return {

--- a/style.css
+++ b/style.css
@@ -20,6 +20,8 @@ body {
   display: flex;
   justify-content: center;
   align-items: center;
+
+  overflow: hidden;
 }
 .container {
   max-width: 930px;
@@ -70,6 +72,7 @@ body {
 }
 .tab_category {
   z-index: 10;
+  white-space: nowrap;
 }
 .tab-count {
   display: none;
@@ -90,6 +93,9 @@ body {
 }
 .category-selected .tab_progress-bar {
   animation: progress 5s linear infinite;
+}
+.category-selected svg {
+  display: block;
 }
 :not(.category-selected):hover > .tab_category {
   text-decoration-line: underline;

--- a/styles/components/list-view.css
+++ b/styles/components/list-view.css
@@ -7,11 +7,12 @@
   border: 1px solid var(--color-border-default);
 }
 .list-view_tab {
-  width: 100%;
   height: 40px;
 
   border-bottom: 1px solid var(--color-border-default);
   background: var(--color-surface-alt);
+
+  overflow-y: scroll;
 }
 .list-view_tab > ul {
   height: 100%;
@@ -29,9 +30,17 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+
+  flex-shrink: 0;
 }
 .list-view_tab > ul > li:hover {
   cursor: pointer;
+}
+.tab-subscribe svg {
+  display: none;
+  width: 14px;
+  height: 14px;
+  z-index: 10;
 }
 .list-view-main {
   padding: 24px;


### PR DESCRIPTION
## :eyes: What is this PR?

구독한 언론사 탭 구현
- close #16
- 내일부터 할일 : 코드를 막짜놓았기 떄문에 코드 리팩토링

## :pencil: Changes

- 그리드뷰 구독한 언론사 탭 구현
- 구독한언론사 탭 그리드 뷰에서 구독 해지시 현재 페이지의 마지막 언론사일 경우 페이지가 전환되어야 하는데 이는 구독리스트가 24로 딱 나누어질 때 prevPage 액션을 dispatch하는 방법으로 ~~약간의 꼼수~~를 사용함
```javascript
const subscribeList = useSelector((state) => state.subscribeList);
    if (subscribeList.length % NEWS_COUNT === 0) {
      store.dispatch(prevPage());
    }
```
- 리스트뷰 구독한 언론사 탭 구현
- 구독한 언론사 탭과 전체 탭을 구분하기 위해 global state로 tabType을 추가로 관리하였으며 구독함수 내에서 tabType에 따른 분기 처리를 해주었음.

## :camera: Attachment(optional)

https://github.com/asdf99245/fe-newsstand/assets/39851220/2076109d-5ee1-4262-8b37-dee2756f41e0



