### PR TITLE
feature: 구독리스트 뷰 탭 draggable 하게 구현

### DIFF
--- a/scripts/list-view.js
+++ b/scripts/list-view.js
@@ -14,9 +14,8 @@ import { openSnackbar } from "../store/reducer/snackbar.js";
 import { addSubscribe } from "../store/reducer/subscribe-list.js";
 import { openModal } from "../store/reducer/modal.js";
 
-const [$categoryTab, $subscribeTab] = document.querySelectorAll(
-  ".list-view_tab > ul"
-);
+const $listViewTab = document.querySelector(".list-view_tab");
+const [$categoryTab, $subscribeTab] = $listViewTab.querySelectorAll("ul");
 const $listViewTabItems = $categoryTab.querySelectorAll("li");
 const $listView = document.querySelector(".list-view-main");
 const $listViewHeader = $listView.querySelector("header");
@@ -40,6 +39,32 @@ const SubscribeItem = (press, selected) => {
       <path d="M9.4 18L8 16.6L12.6 12L8 7.4L9.4 6L15.4 12L9.4 18Z" fill="inherit"/>
     </svg>
   </li>`;
+};
+
+const setSubscribeTabsDraggable = () => {
+  let isMouseDown = false;
+  let startPageX;
+
+  $listViewTab.addEventListener("mousedown", (e) => {
+    isMouseDown = true;
+    startPageX = e.pageX + e.currentTarget.scrollLeft;
+  });
+
+  $listViewTab.addEventListener("mousemove", (e) => {
+    if (!isMouseDown) return;
+    $listViewTab.classList.add("dragging");
+    e.currentTarget.scrollLeft = startPageX - e.pageX;
+  });
+
+  $listViewTab.addEventListener("mouseup", (e) => {
+    isMouseDown = false;
+    $listViewTab.classList.remove("dragging");
+  });
+
+  $listViewTab.addEventListener("mouseleave", () => {
+    isMouseDown = false;
+    $listViewTab.classList.remove("dragging");
+  });
 };
 
 const showSubscribeTab = (subscribeList, selected) => {
@@ -122,6 +147,7 @@ const handleSubscribeTabsClick = (e) => {
   const subscribeList = useSelector((state) => state.subscribeList);
   const pressName = e.target.innerText;
 
+  console.log(e.target);
   const pressIdx = subscribeList.indexOf(pressName);
   store.dispatch(setPage(pressIdx));
 };
@@ -150,6 +176,8 @@ export const renderListView = () => {
   });
   $listViewHeader.addEventListener("click", handleSubscribeButtonClick);
   $subscribeTab.addEventListener("click", handleSubscribeTabsClick);
+
+  setSubscribeTabsDraggable();
 
   store.subscribe(() => {
     const { currentPage, currentCategoryIdx, viewType, tabType } = useSelector(

--- a/style.css
+++ b/style.css
@@ -13,6 +13,7 @@ html {
   background: var(--color-surface-default);
 }
 body {
+  user-select: none;
   position: relative;
   width: 100vw;
   height: 100vh;

--- a/styles/components/list-view.css
+++ b/styles/components/list-view.css
@@ -13,6 +13,12 @@
   background: var(--color-surface-alt);
 
   overflow-y: scroll;
+
+  -ms-overflow-style: none; /* 인터넷 익스플로러 */
+  scrollbar-width: none; /* 파이어폭스 */
+}
+.list-view_tab::-webkit-scrollbar {
+  display: none;
 }
 .list-view_tab > ul {
   height: 100%;
@@ -21,6 +27,9 @@
   align-items: center;
 
   color: var(--color-text-weak);
+}
+.dragging > ul {
+  pointer-events: none;
 }
 .list-view_tab > ul > li {
   position: relative;


### PR DESCRIPTION
## :eyes: What is this PR?

구독한 언론사 탭 리스트뷰에서 탭을 draggable하게 구현

## :pencil: Changes

- 구독 리스트뷰 탭이 넘쳤을 시 마우스 클릭으로 드래그가 가능하게 구현
- `mousedown`, `mousemove`, `mouseup`, `mouseleave`  이벤트를 사용
- 드래그 중이 아닌데도 `mousemove`이벤트가 발생하여 `isMouseDown` boolean 변수를 통해 마우스 다운 중 드래그시에만 `mousemove` 이벤트가 발생하게 함
- scroll 시 엘리먼트의 `scrollLeft`값을 현재 페이지상 마우스의 x좌표와 pageX와 `startPageX`(처음 마우스의 X좌표 + 스크롤 길이)를 통해 이동시킴
- drag가 종료되고 종료된 위치에서의 마우스 이벤트로 인해 카테고리가 변경되는 현상이 발생하여 drag시에는 css `pointer-events` 속성을 none으로 주어 클릭이벤트가 발생하지 않게 했습니다.
```javascript
let isMouseDown = false;
let startPageX;

$listViewTab.addEventListener("mousedown", (e) => {
  isMouseDown = true;
  startPageX = e.pageX + e.currentTarget.scrollLeft;
});

$listViewTab.addEventListener("mousemove", (e) => {
  if (!isMouseDown) return;
  $listViewTab.classList.add("dragging");
  e.currentTarget.scrollLeft = startPageX - e.pageX;
});

$listViewTab.addEventListener("mouseup", (e) => {
  isMouseDown = false;
  $listViewTab.classList.remove("dragging");
});

$listViewTab.addEventListener("mouseleave", () => {
  isMouseDown = false;
  $listViewTab.classList.remove("dragging");
});
```

## :camera: Attachment(optional)

https://github.com/asdf99245/fe-newsstand/assets/39851220/318964ca-9788-4d39-b4c6-1bc8678e284d




